### PR TITLE
Update gallery to pull only from subgraph/IPFS (no image data from FaunaDB)

### DIFF
--- a/apps/web-app/components/ArtGallery/index.js
+++ b/apps/web-app/components/ArtGallery/index.js
@@ -28,11 +28,26 @@ export default function ArtGallery(props) {
 
         try {
             const tokens = await subgraphs.getMintedTokens()
-            const canvas = (await axios.get("/api/fetchCanvases")).data
-            imageData = tokens.map((token) => ({
-                ...token,
-                ...canvas.find((canva) => canva.imageId === token.imageId)
-            }))
+            console.log("TOKENS:", tokens)
+            // const canvas = (await axios.get("/api/fetchCanvases")).data
+            // imageData = tokens.map((token) => ({
+            //     ...token,
+            //     ...canvas.find((canva) => canva.imageId === token.imageId)
+            // }))
+
+            imageData = tokens
+
+            const requests = []
+
+            for (const img of imageData) {
+                requests.push(axios.get(img.uri))
+            }
+
+            const urls = await Promise.all(requests)
+
+            for (let i = 0; i < imageData.length; i++) {
+                imageData[i].imageUri = urls[i].data.image
+            }
         } catch (err) {
             console.error("Error fetching image data", err)
         }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update gallery to pull only from subgraph/IPFS (no image data from FaunaDB) due to issue on Fauna's end.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
